### PR TITLE
Escape HTML characters before inserting Telegram entity tags

### DIFF
--- a/backend/entitiesToHTML.js
+++ b/backend/entitiesToHTML.js
@@ -1,0 +1,83 @@
+export function entitiesToHTML(text, entities = []) {
+  // Escape special characters and map original positions to escaped positions
+  let escaped = "";
+  const map = [];
+  for (let i = 0; i < text.length; i++) {
+    map[i] = escaped.length;
+    const ch = text[i];
+    switch (ch) {
+      case "&":
+        escaped += "&amp;";
+        break;
+      case "<":
+        escaped += "&lt;";
+        break;
+      case ">":
+        escaped += "&gt;";
+        break;
+      case '"':
+        escaped += "&quot;";
+        break;
+      case "'":
+        escaped += "&#39;";
+        break;
+      default:
+        escaped += ch;
+    }
+  }
+  map[text.length] = escaped.length;
+
+  if (!entities || entities.length === 0) return escaped;
+
+  const inserts = [];
+  for (const ent of entities) {
+    let openTag = "", closeTag = "";
+    switch (ent.type) {
+      case "bold":
+        openTag = "<b>";
+        closeTag = "</b>";
+        break;
+      case "italic":
+        openTag = "<i>";
+        closeTag = "</i>";
+        break;
+      case "underline":
+        openTag = "<u>";
+        closeTag = "</u>";
+        break;
+      case "strikethrough":
+        openTag = "<s>";
+        closeTag = "</s>";
+        break;
+      case "code":
+        openTag = "<code>";
+        closeTag = "</code>";
+        break;
+      case "pre":
+        openTag = "<pre>";
+        closeTag = "</pre>";
+        break;
+      case "text_link":
+        openTag = `<a href="${ent.url}" target="_blank">`;
+        closeTag = "</a>";
+        break;
+      case "text_mention":
+        openTag = `<a href="tg://user?id=${ent.user.id}">`;
+        closeTag = "</a>";
+        break;
+    }
+    inserts.push({ pos: map[ent.offset], tag: openTag, order: 1 });
+    inserts.push({ pos: map[ent.offset + ent.length], tag: closeTag, order: 0 });
+  }
+
+  // Sort: descending pos, closing tags first at same position
+  inserts.sort((a, b) => b.pos - a.pos || a.order - b.order);
+
+  // Insert backwards so offsets remain valid
+  let result = escaped;
+  for (const ins of inserts) {
+    result = result.slice(0, ins.pos) + ins.tag + result.slice(ins.pos);
+  }
+
+  return result;
+}

--- a/backend/entitiesToHTML.test.js
+++ b/backend/entitiesToHTML.test.js
@@ -1,0 +1,18 @@
+import assert from "assert";
+import { entitiesToHTML } from "./entitiesToHTML.js";
+
+// Plain text escaping
+assert.strictEqual(
+  entitiesToHTML("2 < 3 > 1 & \"quote\" 'test'"),
+  "2 &lt; 3 &gt; 1 &amp; &quot;quote&quot; &#39;test&#39;"
+);
+
+// Text with entity around characters next to < and >
+const text = "<tag>";
+const entities = [{ type: "bold", offset: 1, length: 3 }];
+assert.strictEqual(
+  entitiesToHTML(text, entities),
+  "&lt;<b>tag</b>&gt;"
+);
+
+console.log("entitiesToHTML tests passed");


### PR DESCRIPTION
## Summary
- escape &, <, >, " and ' in message text before inserting Telegram entity tags
- replace in-server helper with reusable module and add basic unit test

## Testing
- `node backend/entitiesToHTML.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a81c876f588333b7f8ff906450d451