### PR TITLE
Remove redundant frontend static middleware

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -108,9 +108,6 @@ app.get("/api/quotes-ar", async (req, res) => {
   }
 });
 
-// --- Serve frontend ---
-app.use(express.static("../frontend"));
-
 // --- Start server ---
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- consolidate frontend serving by relying on `frontendPath`
- drop duplicate `app.use(express.static("../frontend"))` middleware

## Testing
- `node backend/entitiesToHTML.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a81d49bf0c8333b6399f5a819dae8a