### PR TITLE
Fix footer max-height CSS property

### DIFF
--- a/frontend/footer/footer.css
+++ b/frontend/footer/footer.css
@@ -5,7 +5,7 @@
 
   padding: 0 !important;             /* small padding for slim height */
   grid-column: 1 / -1;           /* span full width across grid */
-  #max-height: 32px;
+  max-height: 32px;
   font-family: "Montserrat", sans-serif;
   color: #76d3ff;
   max-height: 10vh;


### PR DESCRIPTION
## Summary
- Correct invalid CSS comment in footer by turning `#max-height` into a valid `max-height` property.

## Testing
- `node backend/entitiesToHTML.test.js`
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a81e3ed7e48333aa94049941368d02