### PR TITLE
Replace quote border progress with bottom progress bars

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,11 +31,13 @@
     <!-- Middle: Albanian quotes -->
     <div class="box quote-box" id="quoteBoxSq">
       <div id="quotesSq">—</div>
+      <div class="progress"><div class="progress-bar" id="progressSq"></div></div>
     </div>
 
     <!-- Right: Arabic quotes -->
     <div class="box quote-box" id="quoteBoxAr">
       <div id="quotesAr">—</div>
+      <div class="progress"><div class="progress-bar" id="progressAr"></div></div>
     </div>
 
     <!-- Footer Section -->

--- a/frontend/quotes-ar/quotes-ar.js
+++ b/frontend/quotes-ar/quotes-ar.js
@@ -7,15 +7,16 @@ async function loadQuoteAr() {
     document.getElementById("quotesAr").innerHTML = ar.quote;
     refreshIntervalAr = Math.min(120, Math.max(20, ar.quote.length * 1.2 / 10));
     remainingAr = refreshIntervalAr;
+    progressAr.style.width = "100%";
   }
 }
 
-const boxAr = document.getElementById("quoteBoxAr");
+const progressAr = document.getElementById("progressAr");
 
 function updateProgressAr() {
   if (remainingAr > 0) remainingAr -= 0.1;
   const percent = (remainingAr / refreshIntervalAr * 100);
-  boxAr.style.setProperty("--progress", percent + "%");
+  progressAr.style.width = percent + "%";
   if (remainingAr <= 0) loadQuoteAr();
 }
 

--- a/frontend/quotes-sq/quotes-sq.js
+++ b/frontend/quotes-sq/quotes-sq.js
@@ -7,15 +7,16 @@ async function loadQuoteSq() {
     document.getElementById("quotesSq").innerHTML = sq.quote;
     refreshIntervalSq = Math.min(120, Math.max(20, sq.quote.length * 1.2 / 10));
     remainingSq = refreshIntervalSq;
+    progressSq.style.width = "100%";
   }
 }
 
-const boxSq = document.getElementById("quoteBoxSq");
+const progressSq = document.getElementById("progressSq");
 
 function updateProgressSq() {
   if (remainingSq > 0) remainingSq -= 0.1;
   const percent = (remainingSq / refreshIntervalSq * 100);
-  boxSq.style.setProperty("--progress", percent + "%");
+  progressSq.style.width = percent + "%";
   if (remainingSq <= 0) loadQuoteSq();
 }
 

--- a/frontend/shared.css
+++ b/frontend/shared.css
@@ -36,28 +36,24 @@ body {
 .quote-box {
   justify-content: center;
   text-align: center;
-  padding: 1vh 5vw;
+  padding: 1vh 5vw 20px;
+  position: relative;
 }
 
-/* Progress border around quote box */
-.quote-box {
-  position: relative; /* important so ::before stays on it */
-}
-
-.quote-box::before {
-  content: "";
+.progress {
   position: absolute;
-  inset: 0;
-  border-radius: 24px; /* match .box radius */
-  padding: 3px; /* thickness of the progress border */
-  background: conic-gradient(
-    #76d3ff var(--progress, 0%),
-    transparent var(--progress, 0%)
-  );
-  -webkit-mask: 
-    linear-gradient(#000 0 0) content-box, 
-    linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 6px;
+  background: rgba(255,255,255,0.2);
+  border-bottom-left-radius: 24px;
+  border-bottom-right-radius: 24px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0%;
+  background: #76d3ff;
 }


### PR DESCRIPTION
## Summary
- Replace conic-gradient quote box border with simple progress bars at the bottom of each quote box
- Update JavaScript logic to control progress bar widths for Arabic and Albanian quotes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a81ff25958833395a393518e187920