### PR TITLE
Display hashtags as quote title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,12 +30,14 @@
 
     <!-- Middle: Albanian quotes -->
     <div class="box quote-box" id="quoteBoxSq">
+      <div class="quote-title" id="quoteTitleSq"></div>
       <div id="quotesSq">—</div>
       <div class="progress"><div class="progress-bar" id="progressSq"></div></div>
     </div>
 
     <!-- Right: Arabic quotes -->
     <div class="box quote-box" id="quoteBoxAr">
+      <div class="quote-title" id="quoteTitleAr"></div>
       <div id="quotesAr">—</div>
       <div class="progress"><div class="progress-bar" id="progressAr"></div></div>
     </div>

--- a/frontend/quotes-ar/quotes-ar.js
+++ b/frontend/quotes-ar/quotes-ar.js
@@ -4,14 +4,19 @@ let remainingAr = refreshIntervalAr;
 async function loadQuoteAr() {
   const ar = await fetch("/api/quotes-ar").then(r => r.json());
   if (ar.quote) {
-    document.getElementById("quotesAr").innerHTML = ar.quote;
-    refreshIntervalAr = Math.min(120, Math.max(20, ar.quote.length * 1.2 / 10));
+    const parts = ar.quote.trim().split("\n");
+    const title = parts.pop();
+    const body = parts.join("\n");
+    document.getElementById("quotesAr").innerHTML = body;
+    quoteTitleAr.textContent = title;
+    refreshIntervalAr = Math.min(120, Math.max(20, body.length * 1.2 / 10));
     remainingAr = refreshIntervalAr;
     progressAr.style.width = "100%";
   }
 }
 
 const progressAr = document.getElementById("progressAr");
+const quoteTitleAr = document.getElementById("quoteTitleAr");
 
 function updateProgressAr() {
   if (remainingAr > 0) remainingAr -= 0.1;

--- a/frontend/quotes-sq/quotes-sq.js
+++ b/frontend/quotes-sq/quotes-sq.js
@@ -4,14 +4,19 @@ let remainingSq = refreshIntervalSq;
 async function loadQuoteSq() {
   const sq = await fetch("/api/quotes-sq").then(r => r.json());
   if (sq.quote) {
-    document.getElementById("quotesSq").innerHTML = sq.quote;
-    refreshIntervalSq = Math.min(120, Math.max(20, sq.quote.length * 1.2 / 10));
+    const parts = sq.quote.trim().split("\n");
+    const title = parts.pop();
+    const body = parts.join("\n");
+    document.getElementById("quotesSq").innerHTML = body;
+    quoteTitleSq.textContent = title;
+    refreshIntervalSq = Math.min(120, Math.max(20, body.length * 1.2 / 10));
     remainingSq = refreshIntervalSq;
     progressSq.style.width = "100%";
   }
 }
 
 const progressSq = document.getElementById("progressSq");
+const quoteTitleSq = document.getElementById("quoteTitleSq");
 
 function updateProgressSq() {
   if (remainingSq > 0) remainingSq -= 0.1;


### PR DESCRIPTION
## Summary
- Parse last line of each quote as a title and display it separately above the quote
- Keep progress bar anchored inside quote boxes at the bottom

## Testing
- `node backend/entitiesToHTML.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a87a1c29fc8333ab2e89b2f9ac28b7