### PR TITLE
style: update quote progress bar color and position

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,16 +29,20 @@
     </div>
 
     <!-- Middle: Albanian quotes -->
-    <div class="box quote-box" id="quoteBoxSq">
-      <div class="quote-title" id="quoteTitleSq"></div>
-      <div id="quotesSq">—</div>
+    <div class="box">
+      <div class="quote-box" id="quoteBoxSq">
+        <div class="quote-title" id="quoteTitleSq"></div>
+        <div id="quotesSq">—</div>
+      </div>
       <div class="progress"><div class="progress-bar" id="progressSq"></div></div>
     </div>
 
     <!-- Right: Arabic quotes -->
-    <div class="box quote-box" id="quoteBoxAr">
-      <div class="quote-title" id="quoteTitleAr"></div>
-      <div id="quotesAr">—</div>
+    <div class="box">
+      <div class="quote-box" id="quoteBoxAr">
+        <div class="quote-title" id="quoteTitleAr"></div>
+        <div id="quotesAr">—</div>
+      </div>
       <div class="progress"><div class="progress-bar" id="progressAr"></div></div>
     </div>
 

--- a/frontend/shared.css
+++ b/frontend/shared.css
@@ -34,26 +34,25 @@ body {
 }
 
 .quote-box {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   justify-content: center;
   text-align: center;
   padding: 1vh 5vw 20px;
-  position: relative;
 }
 
 .progress {
-  position: absolute;
-  left: 0;
-  bottom: 0;
   width: 100%;
   height: 6px;
-  background: rgba(255,255,255,0.2);
-  border-bottom-left-radius: 24px;
-  border-bottom-right-radius: 24px;
+  background: #faf0a3;
+  border-radius: 24px;
   overflow: hidden;
+  margin-top: auto;
 }
 
 .progress-bar {
   height: 100%;
   width: 0%;
-  background: #76d3ff;
+  background: #f4cb17;
 }


### PR DESCRIPTION
## Summary
- move quote progress bars outside quote containers so they sit below them
- style progress bars with #f4cb17 fill and #faf0a3 track

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a87b0f54448333b124f7c8013a24e0