### PR TITLE
Add admin theme selection with light and dark modes

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Admin - Theme</title>
+  <link rel="stylesheet" href="shared.css">
+  <style>
+    body { flex-direction: column; gap: 1rem; }
+    #themeSelect { padding: 0.5rem; font-size: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Select Theme</h1>
+  <select id="themeSelect">
+    <option value="default">Default</option>
+    <option value="light">Light</option>
+    <option value="dark">Dark</option>
+  </select>
+  <script src="theme.js"></script>
+  <script>
+    const select = document.getElementById('themeSelect');
+    const current = localStorage.getItem('theme') || 'default';
+    select.value = current;
+    select.addEventListener('change', function() {
+      setTheme(this.value);
+    });
+  </script>
+</body>
+</html>

--- a/frontend/footer/footer.css
+++ b/frontend/footer/footer.css
@@ -5,7 +5,7 @@
   padding: 0 !important;             /* small padding for slim height */
   grid-column: 1 / -1;           /* span full width across grid */
   font-family: "Montserrat", sans-serif;
-  color: #76d3ff;  
+  color: var(--accent-color);
   line-height: 0.1;  /* tighter vertical alignment */
 }
 
@@ -18,11 +18,11 @@
 
 .next-label {
   font-size: 2vw;
-  color: #cfe1ff;
+  color: var(--secondary-accent);
 }
 
 .next-time {
   font-size: 2vw;
   font-weight: 700;
-  color: #1ee3ae;
+  color: var(--success-color);
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="quotes-sq/quotes-sq.css">
   <link rel="stylesheet" href="quotes-ar/quotes-ar.css">
   <link rel="stylesheet" href="footer/footer.css">
+  <script src="theme.js" defer></script>
 </head>
 <body>
   <div class="container">

--- a/frontend/prayer/prayer.css
+++ b/frontend/prayer/prayer.css
@@ -31,10 +31,10 @@
   padding: 10px; 
 }
 
-.prayer-name { 
-  font-size: 14px; 
-  margin-bottom: 6px; 
-  color: #cfe1ff; 
+.prayer-name {
+  font-size: 14px;
+  margin-bottom: 6px;
+  color: var(--secondary-accent);
 }
 
 .prayer-time { 

--- a/frontend/quotes-ar/quotes-ar.css
+++ b/frontend/quotes-ar/quotes-ar.css
@@ -4,7 +4,7 @@
   font-weight: 700;
   font-size: clamp(16px, 1vw, 36px); /* keep responsive title */
   margin-bottom: 12px;
-  color: #76d3ff;
+  color: var(--accent-color);
 }
 
 /* Arabic text */

--- a/frontend/quotes-sq/quotes-sq.css
+++ b/frontend/quotes-sq/quotes-sq.css
@@ -4,7 +4,7 @@
   font-weight: 700;
   font-size: clamp(16px, 1vw, 36px); /* keep responsive title */
   margin-bottom: 12px;
-  color: #76d3ff;
+  color: var(--accent-color);
 }
 
 /* Albanian text */

--- a/frontend/shared.css
+++ b/frontend/shared.css
@@ -3,12 +3,21 @@ body {
   font-family: "Montserrat", system-ui, sans-serif;
   background: url('https://images.unsplash.com/photo-1619441207978-3d326c46e2c9?ixlib=rb-4.0.3&auto=format&fit=crop&w=1950&q=80') no-repeat center center fixed;
   background-size: cover;
-  color: #fff;
+  color: var(--text-color);
   height: 100vh;
   width: 100vw;
   display: flex;
   justify-content: center;
   align-items: stretch;
+
+  /* default theme variables */
+  --text-color: #fff;
+  --box-bg: rgba(30,30,30,0.4);
+  --accent-color: #76d3ff;
+  --secondary-accent: #cfe1ff;
+  --success-color: #1ee3ae;
+  --progress-bg: rgba(255, 255, 255, 0.35);
+  --progress-bar-bg: linear-gradient(90deg, #f4cb17, #faf0a3);
 }
 
 /* === Main grid: full screen fixed === */
@@ -21,7 +30,7 @@ body {
 
 /* === Generic box style === */
 .box {
-  background: rgba(30,30,30,0.4);
+  background: var(--box-bg);
   backdrop-filter: blur(14px);
   border-radius: 24px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.5);
@@ -100,7 +109,7 @@ body {
     transform: translateX(-50%);
     width: 80%;
     height: 16px;
-    background: rgba(255, 255, 255, 0.35);
+    background: var(--progress-bg);
     border-radius: 24px;
     overflow: hidden;
     z-index: 0;
@@ -109,7 +118,7 @@ body {
 
   .progress-bar {
     height: 100%;
-    background: linear-gradient(90deg, #f4cb17, #faf0a3);
+    background: var(--progress-bar-bg);
     border-radius: inherit;
 
     /* GPU-friendly transform animation */
@@ -123,3 +132,26 @@ body {
     from { transform: scaleX(1); }
     to   { transform: scaleX(0); }
   }
+
+/* === Theme overrides === */
+body.theme-light {
+  --text-color: #000;
+  --box-bg: rgba(255, 255, 255, 0.8);
+  --accent-color: #007acc;
+  --secondary-accent: #005a99;
+  --success-color: #00732d;
+  --progress-bg: rgba(0, 0, 0, 0.15);
+  --progress-bar-bg: linear-gradient(90deg, #007acc, #a0d3ff);
+  background: #f5f5f5;
+}
+
+body.theme-dark {
+  --text-color: #fff;
+  --box-bg: rgba(0, 0, 0, 0.6);
+  --accent-color: #76d3ff;
+  --secondary-accent: #cfe1ff;
+  --success-color: #1ee3ae;
+  --progress-bg: rgba(255, 255, 255, 0.35);
+  --progress-bar-bg: linear-gradient(90deg, #f4cb17, #faf0a3);
+  background: #000;
+}

--- a/frontend/theme.js
+++ b/frontend/theme.js
@@ -1,0 +1,11 @@
+(function() {
+  const theme = localStorage.getItem('theme') || 'default';
+  document.body.className = `theme-${theme}`;
+})();
+
+function setTheme(theme) {
+  document.body.className = `theme-${theme}`;
+  localStorage.setItem('theme', theme);
+}
+
+window.setTheme = setTheme;


### PR DESCRIPTION
## Summary
- add `theme.js` and `admin.html` so admins can pick between default, light, and dark themes
- refactor shared styles to use CSS variables with light and dark overrides
- update existing components to honor theme variables

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8880f62248333be9d9035e75be48c